### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
+    "@babel/core": "^7.9.6",
     "babel-loader": "^8.1.0",
     "css-loader": "^3.5.2",
     "postcss-loader": "^3.0.0",


### PR DESCRIPTION
Hello, I've had some problems with starting example:
```
$ npm start
> g6-in-react@1.0.0 start /home/bond/work/own/g6-in-react
> webpack-dev-server --config webpack.config.js

ℹ ｢wds｣: Project is running at http://localhost:8080/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from ./dist
ℹ ｢wds｣: 404s will fallback to /index.html
✖ ｢wdm｣: Hash: a6abcb14e42d6f0cff31
Version: webpack 4.43.0
Time: 227ms
Built at: 2020-05-01 21:28:42
 1 asset
Entrypoint g6InReact = g6InReact.min.js
[0] multi (webpack)-dev-server/client?http://localhost:8080 webpack-dev-server/client?http://localhost:8080 ./pages/index.js 52 bytes {g6InReact} [built]
[1] multi webpack-dev-server/client?http://localhost:8080 ./pages/index.js 40 bytes [built]
[./node_modules/webpack-dev-server/client/index.js?http://localhost:8080] (webpack)-dev-server/client?http://localhost:8080 1.51 KiB {g6InReact} [not cacheable] [built] [failed] [1 error]
[./pages/index.js] 1.51 KiB {g6InReact} [not cacheable] [built] [failed] [1 error]

ERROR in ./pages/index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/core'
 babel-loader@8 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:655:15)
    at Function.Module._load (internal/modules/cjs/loader.js:580:25)
    at Module.require (internal/modules/cjs/loader.js:711:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at Object.<anonymous> (/home/bond/work/own/g6-in-react/node_modules/babel-loader/lib/index.js:10:11)
    at Module._compile (internal/modules/cjs/loader.js:805:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:816:10)
    at Module.load (internal/modules/cjs/loader.js:672:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:612:12)
    at Function.Module._load (internal/modules/cjs/loader.js:604:3)
    at Module.require (internal/modules/cjs/loader.js:711:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at loadLoader (/home/bond/work/own/g6-in-react/node_modules/loader-runner/lib/loadLoader.js:18:17)
    at iteratePitchingLoaders (/home/bond/work/own/g6-in-react/node_modules/loader-runner/lib/LoaderRunner.js:169:2)
    at runLoaders (/home/bond/work/own/g6-in-react/node_modules/loader-runner/lib/LoaderRunner.js:365:2)
    at NormalModule.doBuild (/home/bond/work/own/g6-in-react/node_modules/webpack/lib/NormalModule.js:295:3)
 @ multi webpack-dev-server/client?http://localhost:8080 ./pages/index.js g6InReact[1]

ERROR in (webpack)-dev-server/client?http://localhost:8080
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/core'
 babel-loader@8 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:655:15)
    at Function.Module._load (internal/modules/cjs/loader.js:580:25)
    at Module.require (internal/modules/cjs/loader.js:711:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at Object.<anonymous> (/home/bond/work/own/g6-in-react/node_modules/babel-loader/lib/index.js:10:11)
    at Module._compile (internal/modules/cjs/loader.js:805:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:816:10)
    at Module.load (internal/modules/cjs/loader.js:672:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:612:12)
    at Function.Module._load (internal/modules/cjs/loader.js:604:3)
    at Module.require (internal/modules/cjs/loader.js:711:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at loadLoader (/home/bond/work/own/g6-in-react/node_modules/loader-runner/lib/loadLoader.js:18:17)
    at iteratePitchingLoaders (/home/bond/work/own/g6-in-react/node_modules/loader-runner/lib/LoaderRunner.js:169:2)
    at runLoaders (/home/bond/work/own/g6-in-react/node_modules/loader-runner/lib/LoaderRunner.js:365:2)
    at NormalModule.doBuild (/home/bond/work/own/g6-in-react/node_modules/webpack/lib/NormalModule.js:295:3)
 @ multi (webpack)-dev-server/client?http://localhost:8080 webpack-dev-server/client?http://localhost:8080 ./pages/index.js g6InReact[0]
Child HtmlWebpackCompiler:
     1 asset
    Entrypoint HtmlWebpackPlugin_0 = __child-HtmlWebpackPlugin_0
    [./node_modules/html-webpack-plugin/lib/loader.js!./pages/index.html] 392 bytes {HtmlWebpackPlugin_0} [built]
ℹ ｢wdm｣: Failed to compile.
```

Looks like culprit is here: `babel-loader@8 requires Babel 7.x (the package '@babel/core')` 
`npm install @babel/core` fixed issue for me, so I've added missing `@babel/core` to devDependencies.

(Thanks for awesome demo btw.)