### PR TITLE
Add ResizeObserver to correctly size graph

### DIFF
--- a/pages/app.js
+++ b/pages/app.js
@@ -143,13 +143,27 @@ export default function() {
     graph.paint()
 
     bindEvents()
+
+    const resizeGraph = (entries) => {
+      if (!graph || graph.get("destroyed")) return
+      graph.changeSize(entries[0].contentRect.width, entries[0].contentRect.height)
+    }
+    const ro = new ResizeObserver(resizeGraph)
+    ro.observe(ref.current)
+
+    return () => {
+      graph = null
+      ro.unobserve(ref.current)
+    };
   }, [])
 
   return (
-    <div ref={ref}>
-      { showEdgeTooltip && <EdgeToolTips x={edgeTooltipX} y={edgeTooltipY} /> }
-      { showNodeTooltip && <NodeTooltips x={nodeTooltipX} y={nodeTooltipY} /> }
-      { showNodeContextMenu && <NodeContextMenu x={nodeContextMenuX} y={nodeContextMenuY} /> }
-    </div>
+      <div style={{background: "gray", padding: "1em", height: "100vh", width: "100vw"}}>
+        <div ref={ref} style={{background: "white", height: "100%", width: "100%", position: "relative"}}>
+          {showEdgeTooltip && <EdgeToolTips x={edgeTooltipX} y={edgeTooltipY}/>}
+          {showNodeTooltip && <NodeTooltips x={nodeTooltipX} y={nodeTooltipY}/>}
+          {showNodeContextMenu && <NodeContextMenu x={nodeContextMenuX} y={nodeContextMenuY}/>}
+        </div>
+      </div>
   );
 }

--- a/pages/index.html
+++ b/pages/index.html
@@ -2,6 +2,12 @@
   <head>
       <meta charset="utf-8"/>
       <title>G6 & React</title>
+      <style>
+          .g6-minimap {
+              position: absolute;
+              bottom: 0;
+          }
+      </style>
   </head>
   <body>
     <div id="container"></div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './tutorital.jsx';
+import App from './app.js';
 
 ReactDOM.render(<App/>, document.getElementById('container'));


### PR DESCRIPTION
When using the examples, I had the problem that the graph was smaller than the box I had allocated in the existing Ant Design layout. Adding a ResizeObserver fixes this problem in Safari and Firefox.
Note that this requires a fixed container size to work correctly.

I also added some CSS for the minimap position right into `index.html` as a quick fix.